### PR TITLE
Add configuration configuration base

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gem 'dotenv'
 gem "rake"
 
 group :test do
+  gem "activesupport"
   gem "rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
     builder (3.2.2)
     coderay (1.1.1)
+    concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     dotenv (2.1.1)
     gyoku (1.3.1)
@@ -13,8 +19,10 @@ GEM
     httpi (2.4.2)
       rack
       socksify
+    i18n (0.7.0)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
+    minitest (5.9.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     nori (2.6.0)
@@ -47,6 +55,9 @@ GEM
       wasabi (~> 3.4)
     slop (3.6.0)
     socksify (1.7.0)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
@@ -55,6 +66,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   dotenv
   pry
   rake

--- a/lib/mindbody.rb
+++ b/lib/mindbody.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require "mindbody/configuration"
+
+module Mindbody
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration
+  end
+end

--- a/lib/mindbody/configuration.rb
+++ b/lib/mindbody/configuration.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module Mindbody
+  class Configuration
+    attr_accessor :source_name
+  end
+end

--- a/spec/lib/mindbody/configuration_spec.rb
+++ b/spec/lib/mindbody/configuration_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "active_support/core_ext/object/blank"
+require "spec_helper"
+
+require "mindbody/configuration"
+
+RSpec.describe Mindbody::Configuration do
+  describe "#source_name" do
+    it "is empty by default" do
+      config = described_class.new
+
+      expect(config.source_name).to be_blank
+    end
+  end
+
+  describe "#source_name=" do
+    it "sets the value of #source_name" do
+      source_name = "test"
+      config = described_class.new
+
+      config.source_name = source_name
+
+      expect(config.source_name).to eq source_name
+    end
+  end
+end

--- a/spec/lib/mindbody_spec.rb
+++ b/spec/lib/mindbody_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+require "mindbody"
+
+RSpec.describe Mindbody do
+  describe ".configuration" do
+    it "returns a Mindbody::Configuration object" do
+      expect(Mindbody.configuration).to be_a ::Mindbody::Configuration
+    end
+
+    context "when it is called multiple times" do
+      it "always returns the same object" do
+        config = Mindbody.configuration
+        times = rand(1..10)
+
+        objects = Array.new(times).map{ Mindbody.configuration }.uniq
+
+        expect(objects).to match_array [config]
+      end
+    end
+  end
+
+  describe ".configure" do
+    context "when the source name is changed" do
+      it "retains that change in the configuration" do
+        source_name = "test"
+
+        Mindbody.configure do |c|
+          c.source_name = source_name
+        end
+
+        expect(Mindbody.configuration.source_name).to eq source_name
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why:

* Most methods in the MindBody Online API require some information to be
  provided by the user/developer that will not change between methods
  (like credentials) and can be configured once for the whole codebase.

This change addresses the need by:

* Adding `activesupport` for better matchers in specs;
* Adding a `Mindbody` master module that has the configuration API;
* Adding a `Configuration` class to expose all the configuration points;
* Specs were added for all this code.